### PR TITLE
Fix in function dfa_qsort_r.

### DIFF
--- a/qsort.c
+++ b/qsort.c
@@ -157,7 +157,7 @@ loop:   SWAPINIT(a, es);
         r = min(pd - pc, pn - pd - es);
         vecswap(pb, pn - r, r);
         if ((r = pb - pa) > es)
-                qsort_r(a, r / es, es, thunk, cmp);
+                dfa_qsort_r(a, r / es, es, thunk, cmp);
         if ((r = pd - pc) > es) {
                 /* Iterate rather than recurse to save stack space */
                 a = pn - r;


### PR DESCRIPTION
qsort_r was called instead of dfa_qsort_r.
It caused crash on Linux (unlike BSD), bacause the order of arguments in comparator for qsort_r is different on Linux and BSD.

On Linux we have:
    qsort_r comparator type: int (*compar)(const void *, const void *, void *)
    dfa_qsort_r comparator type: typedef int cmp_t(void *, const void *, const void *);
