### PR TITLE
fix build faliure against ghc-7.6

### DIFF
--- a/Data/DFA.hs
+++ b/Data/DFA.hs
@@ -2,7 +2,7 @@
 -- Representation of DFAs and some simple algorithms on them.
 module Data.DFA
        (
-         DFA
+         DFA(..)
        , Label
        , State
 

--- a/Data/DFA/DOT.hs
+++ b/Data/DFA/DOT.hs
@@ -16,7 +16,7 @@ import Prelude hiding ( lex, read )
 import Foreign
 import Foreign.C
 
-import Data.DFA ( DFA, Label )
+import Data.DFA ( DFA(..), Label )
 -- import qualified Data.DFA as DFA
 
 -------------------------------------------------------------------


### PR DESCRIPTION
[2 of 4] Compiling Data.DFA.DOT     ( Data/DFA/DOT.hs, dist/build/Data/DFA/DOT.o )

Data/DFA/DOT.hs:40:1:
    Unacceptable argument type in foreign declaration: DFA
    When checking declaration:
      foreign import ccall safe "static dfa.h DFA_writeDotToFile" writeDotToFile'

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
